### PR TITLE
Add localStorage check and document save feature

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,12 @@ The rules are provided in full in GAMERULES.md, which should be used as the basi
 
 ---
 
+## Save and Load
+
+Starting in the early prototype you can save your progress to the browser's `localStorage` and load it again later. Use the **Save Game** and **Load Game** buttons below the stat bar. The data is stored under the key `tinhelm-save` and includes all values from the global `gameState` object (player stats, level, inventory, etc.).
+
+---
+
 ## ✅ Project Roadmap
 
 ### Phase 1: Scaffolding & Structure

--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
             <div class="stat" id="stat-level">Level: <span class="value" id="level-value">1</span></div>
         </header>
 
+        <div id="save-load-buttons">
+            <button id="save-btn">Save Game</button>
+            <button id="load-btn">Load Game</button>
+        </div>
+
         <main id="dungeon-area">
             <div id="deck-placeholder">Dungeon Deck</div>
             <div class="card dummy-card">
@@ -24,6 +29,7 @@
         </main>
     </div>
 
+    <script src="scripts/gameState.js"></script>
     <script src="scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/gameState.js
+++ b/scripts/gameState.js
@@ -1,0 +1,68 @@
+// Global game state and save/load functionality
+// DataModelAgent & GameLogicAgent will extend this structure as the game grows.
+
+const gameState = {
+    player: {
+        hp: 10,
+        energy: 5,
+        food: 2,
+        favor: 0,
+    },
+    level: 1,
+    decks: {},
+    currentRoom: null,
+    inventory: [],
+    turn: 0,
+    timestamp: Date.now(),
+};
+
+// Check if localStorage is available
+function supportsLocalStorage() {
+    try {
+        const key = '__tinhelm_test__';
+        localStorage.setItem(key, '1');
+        localStorage.removeItem(key);
+        return true;
+    } catch (err) {
+        console.warn('Local storage unavailable:', err);
+        return false;
+    }
+}
+
+function saveGame() {
+    if (!supportsLocalStorage()) return;
+    gameState.timestamp = Date.now();
+    localStorage.setItem('tinhelm-save', JSON.stringify(gameState));
+    console.log('Game saved');
+}
+
+function loadGame() {
+    if (!supportsLocalStorage()) return false;
+    const data = localStorage.getItem('tinhelm-save');
+    if (!data) {
+        console.warn('No saved game found');
+        return false;
+    }
+    try {
+        const loaded = JSON.parse(data);
+        Object.assign(gameState, loaded);
+        console.log('Game loaded');
+        updateUIFromState();
+        return true;
+    } catch (err) {
+        console.error('Failed to parse saved game:', err);
+        return false;
+    }
+}
+
+// Update the displayed stats from gameState
+function updateUIFromState() {
+    const { hp, energy, food, favor } = gameState.player;
+    document.getElementById('hp-value').textContent = hp;
+    document.getElementById('energy-value').textContent = energy;
+    document.getElementById('food-value').textContent = food;
+    document.getElementById('favor-value').textContent = favor;
+    document.getElementById('level-value').textContent = gameState.level;
+}
+
+// GameLogicAgent: call saveGame() at the end of turns or after combat.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,4 +3,33 @@
 
 document.addEventListener('DOMContentLoaded', () => {
     console.log('Tin Helm Web scaffold loaded');
+
+    updateUIFromState();
+
+    const saveBtn = document.getElementById('save-btn');
+    const loadBtn = document.getElementById('load-btn');
+
+    if (!supportsLocalStorage()) {
+        if (saveBtn) saveBtn.disabled = true;
+        if (loadBtn) loadBtn.disabled = true;
+        return;
+    }
+
+    if (saveBtn) {
+        saveBtn.addEventListener('click', () => {
+            saveGame();
+            if (loadBtn) loadBtn.disabled = false;
+        });
+    }
+
+    if (loadBtn) {
+        loadBtn.addEventListener('click', () => {
+            if (!loadGame()) {
+                alert('No saved game found.');
+            }
+        });
+        if (!localStorage.getItem('tinhelm-save')) {
+            loadBtn.disabled = true;
+        }
+    }
 });

--- a/style.css
+++ b/style.css
@@ -24,6 +24,17 @@ body {
     margin-bottom: 1rem;
 }
 
+#save-load-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+#save-load-buttons button {
+    padding: 0.5rem 1rem;
+}
+
 .stat {
     font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary
- document save/load system in README
- add localStorage availability check
- disable save/load buttons when storage unavailable

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68687a5ccf9c832dac81d4d14034fa4c