### PR TITLE
Update encounter modal to require user confirmation

### DIFF
--- a/scripts/gameLogic.js
+++ b/scripts/gameLogic.js
@@ -504,6 +504,7 @@ async function processNextIcon(icons, legendCard, done) {
                         image: gillNetCard.image,
                         dieRoll: true,
                         dieCount: 3,
+                        requireContinue: true,
                         onRoll: rolls => {
                             const s = rolls.filter(r => r >= 4).length;
                             if (s > 0) {
@@ -523,6 +524,7 @@ async function processNextIcon(icons, legendCard, done) {
                         message: 'You found a water source. Roll a die: on a 4+, you gain 1 Ration.',
                         dieRoll: true,
                         dieCount: 1,
+                        requireContinue: true,
                         onRoll: roll => {
                             if (roll >= 4) {
                                 updatePlayerStats('food', 1);
@@ -698,6 +700,7 @@ async function handleReferenceCard(refCard) {
                     message: 'The air hums with ancient energy. Roll a die to see what the grove provides.',
                     image: refCard.image,
                     dieRoll: true,
+                    requireContinue: true,
                     onRoll: (roll) => {
                         let foodGained = 0;
                         if (roll === 1) {
@@ -1388,6 +1391,7 @@ async function processAllItemEffects(eventContext) {
                                     message: 'You can use your Toolkit to try and disarm the trap. Roll a die: a 4+ means you succeed!',
                                     image: item.image,
                                     dieRoll: true,
+                                    requireContinue: true,
                                     onRoll: (roll) => {
                                         if (roll >= 4) {
                                             eventContext.trapContext.bypassed = true;

--- a/scripts/ui.encounterModal.js
+++ b/scripts/ui.encounterModal.js
@@ -16,83 +16,98 @@ import { animateDiceRoll } from './ui.dice.js';
  * @param {number} [options.dieCount=1] - The number of dice to roll.
  * @param {function(Array<number>|number)} [options.onRoll] - Callback executed after dice are rolled.
  */
-export async function showEncounterModal({ title = '', message = '', image, choices = [], onChoice, dieRoll = false, dieCount = 1, onRoll }) {
-    const encounterArea = document.getElementById('combat-area');
-    if (!encounterArea) {
-        console.error('Encounter area (#combat-area) not found.');
-        return;
-    }
-
-    // Before clearing, unmount any existing React component (like the combat board)
-    await hideCombatBoard();
-
-    // Clear previous content (e.g., combat board or another modal)
-    encounterArea.innerHTML = '';
-
-    const modalArea = document.createElement('div');
-    modalArea.className = 'encounter-modal-area';
-
-    let choicesHTML = '';
-    if (choices && choices.length) {
-        choicesHTML = `<div class="encounter-modal-actions">${choices.map(opt => `<button class="choice-btn" data-value="${opt.value}">${opt.label}</button>`).join('')}</div>`;
-    }
-
-    let dieRollHTML = '';
-    if (dieRoll) {
-        dieRollHTML = `
-            <div class="encounter-dice-row" style="margin:1em 0;">
-                ${Array.from({ length: dieCount || 1 }).map(() => `<span class="encounter-die" style="font-size:2em;display:inline-block;min-width:1.5em;text-align:center;margin-right:0.3em;">?</span>`).join('')}
-            </div>
-            <div>
-                <button id="encounter-roll-btn">${dieCount > 1 ? `Roll ${dieCount} Dice` : 'Roll Die'}</button>
-            </div>
-        `;
-    }
-
-    modalArea.innerHTML = `
-        ${title ? `<h2>${title}</h2>` : ''}
-        ${image ? `<div class="encounter-modal-image-wrap"><img src="${image}" alt="${title}" class="encounter-modal-image" style="max-width:220px;margin:0.5em auto;display:block;border-radius:12px;"></div>` : ''}
-        ${message ? `<div class="encounter-modal-message">${message}</div>` : ''}
-        ${dieRollHTML}
-        ${choicesHTML}
-    `;
-
-    encounterArea.appendChild(modalArea);
-
-    // Add event listeners
-    if (choices && choices.length) {
-        modalArea.querySelectorAll('.choice-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const value = e.target.getAttribute('data-value');
-                if (onChoice) {
-                    onChoice(value);
-                }
-                hideEncounterModal(); // Automatically close on choice
-            });
-        });
-    }
-
-    if (dieRoll) {
-        const rollBtn = document.getElementById('encounter-roll-btn');
-        if (rollBtn) {
-            rollBtn.onclick = () => {
-                rollBtn.disabled = true;
-                const rolls = Array.from({ length: dieCount || 1 }, () => Math.floor(Math.random() * 6) + 1);
-                const diceEls = modalArea.querySelectorAll('.encounter-die');
-                
-                animateDiceRoll(diceEls, rolls, () => {
-                    diceEls.forEach((el, i) => { el.textContent = rolls[i]; });
-                    if (onRoll) {
-                        onRoll(dieCount > 1 ? rolls : rolls[0]);
-                    }
-                    // If there are no choices, close the modal after the roll animation
-                    if (!choices || choices.length === 0) {
-                        setTimeout(hideEncounterModal, 1000);
-                    }
-                });
-            };
+export async function showEncounterModal({ title = '', message = '', image, choices = [], onChoice, dieRoll = false, dieCount = 1, onRoll, requireContinue = false }) {
+    return new Promise(async (resolve) => {
+        const encounterArea = document.getElementById('combat-area');
+        if (!encounterArea) {
+            console.error('Encounter area (#combat-area) not found.');
+            resolve();
+            return;
         }
-    }
+
+        // Before clearing, unmount any existing React component (like the combat board)
+        await hideCombatBoard();
+
+        // Clear previous content (e.g., combat board or another modal)
+        encounterArea.innerHTML = '';
+
+        const modalArea = document.createElement('div');
+        modalArea.className = 'encounter-modal-area';
+
+        let btnChoices = Array.isArray(choices) ? [...choices] : [];
+        if (btnChoices.length === 0 || requireContinue) {
+            btnChoices.push({ label: 'Continue', value: 'continue' });
+        }
+
+        let choicesHTML = '';
+        if (btnChoices.length) {
+            choicesHTML = `<div class="encounter-modal-actions">${btnChoices.map(opt => `<button class="choice-btn" data-value="${opt.value}">${opt.label}</button>`).join('')}</div>`;
+        }
+
+        let dieRollHTML = '';
+        if (dieRoll) {
+            dieRollHTML = `
+                <div class="encounter-dice-row" style="margin:1em 0;">
+                    ${Array.from({ length: dieCount || 1 }).map(() => `<span class="encounter-die" style="font-size:2em;display:inline-block;min-width:1.5em;text-align:center;margin-right:0.3em;">?</span>`).join('')}
+                </div>
+                <div>
+                    <button id="encounter-roll-btn">${dieCount > 1 ? `Roll ${dieCount} Dice` : 'Roll Die'}</button>
+                </div>
+            `;
+        }
+
+        modalArea.innerHTML = `
+            ${title ? `<h2>${title}</h2>` : ''}
+            ${image ? `<div class="encounter-modal-image-wrap"><img src="${image}" alt="${title}" class="encounter-modal-image" style="max-width:220px;margin:0.5em auto;display:block;border-radius:12px;"></div>` : ''}
+            ${message ? `<div class="encounter-modal-message">${message}</div>` : ''}
+            ${dieRollHTML}
+            ${choicesHTML}
+        `;
+
+        encounterArea.appendChild(modalArea);
+
+        // Add event listeners
+        if (btnChoices.length) {
+            modalArea.querySelectorAll('.choice-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    const value = e.target.getAttribute('data-value');
+                    if (onChoice) {
+                        onChoice(value);
+                    }
+                    hideEncounterModal();
+                    resolve(value);
+                });
+            });
+        }
+
+        if (dieRoll) {
+            const rollBtn = document.getElementById('encounter-roll-btn');
+            if (rollBtn) {
+                rollBtn.onclick = () => {
+                    rollBtn.disabled = true;
+                    const rolls = Array.from({ length: dieCount || 1 }, () => Math.floor(Math.random() * 6) + 1);
+                    const diceEls = modalArea.querySelectorAll('.encounter-die');
+
+                    animateDiceRoll(diceEls, rolls, () => {
+                        diceEls.forEach((el, i) => { el.textContent = rolls[i]; });
+                        if (onRoll) {
+                            onRoll(dieCount > 1 ? rolls : rolls[0]);
+                        }
+                    });
+                };
+            }
+            // Disable continue button until the roll is made
+            const contBtn = modalArea.querySelector('.choice-btn[data-value="continue"]');
+            if (contBtn) {
+                contBtn.disabled = true;
+                if (rollBtn) {
+                    rollBtn.addEventListener('click', () => {
+                        contBtn.disabled = false;
+                    });
+                }
+            }
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary
- modify `showEncounterModal` to always provide a Continue option when no choices exist
- make the modal return a promise that resolves when the user clicks
- disable auto-close behaviour and enable continue after dice rolls
- ensure all encounter modal calls that lack choices pass `requireContinue`

## Testing
- `node -c scripts/ui.encounterModal.js`
- `node -c scripts/gameLogic.js`

------
https://chatgpt.com/codex/tasks/task_e_686fcf001614832dbc2e226a39355885