### PR TITLE
Show trap outcome in modal

### DIFF
--- a/scripts/gameLogic.js
+++ b/scripts/gameLogic.js
@@ -443,6 +443,7 @@ async function processNextIcon(icons, legendCard, done) {
         case 'Trap': {
             await hideCombatBoard();
             const trapEffect = legendCard.trap;
+            let trapMessage = '';
             if (trapEffect && typeof trapEffect === 'string') {
                 if (trapEffect !== 'None') {
                     let trapContext = { bypassed: false, effect: trapEffect };
@@ -452,18 +453,33 @@ async function processNextIcon(icons, legendCard, done) {
                         const enMatch = trapEffect.match(/^EN -(\d+)$/);
                         if (hpMatch && hpMatch[1]) {
                             updatePlayerStats('hp', -parseInt(hpMatch[1], 10));
+                            trapMessage = `A trap was triggered! You lost ${hpMatch[1]} HP.`;
                         } else if (enMatch && enMatch[1]) {
                             updatePlayerStats('energy', -parseInt(enMatch[1], 10));
+                            trapMessage = `A trap was triggered! You lost ${enMatch[1]} Energy.`;
                         } else {
                             console.warn("Could not parse trap effect:", trapEffect);
+                            trapMessage = 'A trap was triggered.';
                         }
                     } else {
                         logEvent('Toolkit: Trap bypassed, no effect.');
+                        trapMessage = 'You bypassed the trap.';
                     }
+                } else {
+                    trapMessage = 'There is no trap effect.';
                 }
             } else {
                 console.warn("Trap icon encountered, but no valid trap effect data found on the legend card.", { trapEffect });
+                trapMessage = 'A trap was encountered, but its effect is unclear.';
             }
+            await new Promise(resolve => {
+                showEncounterModal({
+                    title: 'Trap',
+                    message: trapMessage,
+                    choices: [{ label: 'Continue', value: 'ok' }],
+                    onChoice: resolve
+                });
+            });
             break;
         }
         case 'Campsite': {


### PR DESCRIPTION
## Summary
- inform the player about trap outcomes

## Testing
- `node --check scripts/gameLogic.js`

------
https://chatgpt.com/codex/tasks/task_e_686fd4329460832d885f9a91bc7296aa