### PR TITLE
Add manual continue step after combat

### DIFF
--- a/scripts/gameLogic.js
+++ b/scripts/gameLogic.js
@@ -1613,7 +1613,6 @@ if (classData && classData.combatBonusDamageEnergyCost && classData.combatBonusD
             };
 
             updateModal({ roll1: context.roll1, roll2: context.roll2, message, showRollBtn, isCombatOver });
-            if (isCombatOver) setTimeout(resolve, 500);
         }
 showCombatBoard({
     classCard: classCard,

--- a/scripts/ui.combatBoard.js
+++ b/scripts/ui.combatBoard.js
@@ -111,11 +111,11 @@ export function showCombatBoard({ classCard, enemyCard, abilities, canUseAxeRero
                             disabled: isCombatOver
                         }, 'Enemy Roll'),
                         window.React.createElement('button', {
-                            id: 'combat-end-btn',
+                            id: 'combat-continue-btn',
                             className: 'combat-btn-end',
                             style: { display: isCombatOver ? 'block' : 'none', alignSelf: 'stretch', marginTop: '1.2em' },
                             onClick: handleEndCombat
-                        }, 'End Combat'),
+                        }, 'Continue'),
                         window.React.createElement('div', {
                             className: 'combat-energy-row' + (isPlayerTurn ? ' energy-row-active' : ' energy-row-inactive'),
                             style: { marginBottom: '0.5em', transition: 'opacity 0.2s, transform 0.2s' }


### PR DESCRIPTION
## Summary
- add Continue button to combat board
- stop combat from auto-closing

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686fdfb3e3bc832db26e98cb80ea10fa